### PR TITLE
generator の設定を変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ yarn-debug.log*
 .yarn-integrity
 
 /config/database.yml
+erd.pdf

--- a/config/initializers/generators.rb
+++ b/config/initializers/generators.rb
@@ -2,12 +2,13 @@ Rails.application.config.generators do |g|
   g.template_engine false
   g.javascripts false
   g.stylesheets false
-  g.helper true
-  g.factory_bot dir: "spec/factories"
+  g.helper false
   g.test_framework :rspec,
+                   fixtures: true,
                    view_specs: false,
                    routing_specs: false,
                    helper_specs: false,
                    controller_specs: false,
-                   request_specs: true
+                   request_specs: false
+  g.fixture_replacement :factory_bot, dir: "spec/factories"
 end


### PR DESCRIPTION
## 概要
- rails g model xxx で、factory_bot に関するファイルが作成されなかったので、fixture_replacement による記述に変更。
- helper は基本的に使わない方針のため、false に変更
- request spec も必要なときに作成すれば十分なため false に変更 


