### PR TITLE
ダミーデータで対応していた Articles API のテストを修正 / devise_token_auth を使った API のテスト実装

### DIFF
--- a/config/initializers/active_model_serializers.rb
+++ b/config/initializers/active_model_serializers.rb
@@ -1,0 +1,1 @@
+ActiveModel::Serializer.config.adapter = :attributes

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require "rspec/rails"
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -59,4 +59,5 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
+  config.include SessionHelpers
 end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -1,8 +1,5 @@
 require "rails_helper"
 
-# FIXME: devise_token_auth 導入までの一時的なコードなため許容
-# rubocop:disable RSpec/AnyInstance
-
 RSpec.describe "Articles", type: :request do
   describe "GET /articles" do
     subject { get(api_v1_articles_path) }
@@ -56,12 +53,13 @@ RSpec.describe "Articles", type: :request do
   end
 
   describe "POST /articles" do
-    subject { post(api_v1_articles_path, params: params) }
+    subject { post(api_v1_articles_path, params: params, headers: headers) }
 
-    let(:params) { { article: attributes_for(:article) } }
-    # FIXME: devise_token_auth の導入が完了次第修正すること
     let(:current_user) { create(:user) }
-    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+    let(:params) { { article: attributes_for(:article) } }
+    let(:headers) { authentication_headers_for(current_user) }
+
+
 
     it "記事のレコードが作成できる" do
       aggregate_failures do
@@ -72,12 +70,11 @@ RSpec.describe "Articles", type: :request do
   end
 
   describe "PATCH /articles/:id" do
-    subject { patch(api_v1_article_path(article.id), params: params) }
+    subject { patch(api_v1_article_path(article.id), params: params, headers: headers) }
 
-    let(:params) { { article: attributes_for(:article) } }
-    # FIXME: devise_token_auth の導入が完了次第修正すること
     let(:current_user) { create(:user) }
-    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+    let(:params) { { article: attributes_for(:article) } }
+    let(:headers) { authentication_headers_for(current_user) }
 
     context "自分が所持している記事のレコードを更新しようとするとき" do
       let!(:article) { create(:article, user: current_user) }
@@ -105,13 +102,11 @@ RSpec.describe "Articles", type: :request do
   end
 
   describe "DELETE /articles/:id" do
-    subject { delete(api_v1_article_path(article_id)) }
+    subject { delete(api_v1_article_path(article_id), headers: headers) }
 
-    let(:article_id) { article.id }
-
-    # FIXME: devise_token_auth の導入が完了次第修正すること
     let(:current_user) { create(:user) }
-    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+    let(:headers) { authentication_headers_for(current_user) }
+    let(:article_id) { article.id }
 
     context "自分が所持している記事のレコードを削除しようとするとき" do
       let!(:article) { create(:article, user: current_user) }

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -1,0 +1,4 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Auth::Registrations", type: :request do
+end

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -1,4 +1,58 @@
 require "rails_helper"
 
 RSpec.describe "Api::V1::Auth::Registrations", type: :request do
+  describe "POST /api/v1/auth" do
+    subject { post(api_v1_user_registration_path, params: params) }
+
+    context "必要なパラメータを送信したとき" do
+      let(:params) { attributes_for(:user).slice(:name, :email, :password) }
+      it "ユーザーが作成される" do
+        aggregate_failures do
+          expect { subject }.to change { User.count }.by(1)
+
+          data = JSON.parse(response.body)["data"]
+
+          expect(response).to have_http_status(:ok)
+          expect(data["provider"]).to eq "email"
+          expect(data["name"]).to eq params[:name]
+          expect(data["email"]).to eq params[:email]
+        end
+      end
+    end
+
+    context "送信したパラメータに不足があったとき(emailを送信していない)" do
+      let(:params) { attributes_for(:user).slice(:name, :password) }
+
+      it "ユーザーは作成されず、422 Error が発生する" do
+        aggregate_failures do
+          # TODO: 422 Error が発生したときの Error handling
+          expect { subject }.to change { User.count }.by(0)
+
+          res = JSON.parse(response.body)
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(res["errors"]["email"]).to match_array ["can't be blank"]
+        end
+      end
+    end
+
+    context "すでに同一のメールアドレスのユーザー登録があったとき" do
+      before { create(:user, email: email) }
+
+      let(:email) { Faker::Internet.email }
+      let(:params) { attributes_for(:user, email: email).slice(:name, :email, :password) }
+
+      it "ユーザーは作成されず、422 Error が発生する" do
+        aggregate_failures do
+          # TODO: 422 Error が発生したときの Error handling
+          expect { subject }.to change { User.count }.by(0)
+
+          res = JSON.parse(response.body)
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(res["errors"]["email"]).to match_array ["has already been taken"]
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -16,6 +16,15 @@ RSpec.describe "Api::V1::Auth::Registrations", type: :request do
           expect(data["provider"]).to eq "email"
           expect(data["name"]).to eq params[:name]
           expect(data["email"]).to eq params[:email]
+
+          # Header Info
+          # devise_token_auth.rb に書いている設定通りのヘッダー情報が返ってくる。
+          headers = response.headers
+          expect(headers["access-token"]).to be_present
+          expect(headers["client"]).to be_present
+          expect(headers["expiry"]).to be_present
+          expect(headers["uid"]).to be_present
+          expect(headers["token-type"]).to be_present
         end
       end
     end

--- a/spec/requests/api/v1/auth/sessions_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_spec.rb
@@ -1,4 +1,6 @@
 require "rails_helper"
 
 RSpec.describe "Api::V1::Auth::Sessions", type: :request do
+  describe "POST /api/v1/auth/sign_in" do
+  end
 end

--- a/spec/requests/api/v1/auth/sessions_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_spec.rb
@@ -1,0 +1,4 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Auth::Sessions", type: :request do
+end

--- a/spec/requests/api/v1/auth/sessions_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_spec.rb
@@ -2,5 +2,76 @@ require "rails_helper"
 
 RSpec.describe "Api::V1::Auth::Sessions", type: :request do
   describe "POST /api/v1/auth/sign_in" do
+    subject { post(api_v1_user_session_path, params: params) }
+
+    context "登録済みのユーザーの正しいメールアドレスとパスワードを送信したとき" do
+      let!(:user) { create(:user) }
+      let(:params) { { email: user.email, password: user.password } }
+
+      it "トークン情報を取得できる" do
+        subject
+
+        headers = response.headers
+
+        aggregate_failures do
+          expect(response).to have_http_status(:ok)
+          expect(headers["access-token"]).to be_present
+          expect(headers["client"]).to be_present
+          expect(headers["expiry"]).to be_present
+          expect(headers["uid"]).to be_present
+          expect(headers["token-type"]).to be_present
+        end
+      end
+    end
+
+    context "存在しないメールアドレスを送信したとき" do
+      let!(:user) { create(:user) }
+      let(:params) { { email: "000_#{Faker::Internet.email}", password: user.password } }
+
+      it "トークン情報を取得できない" do
+        subject
+
+        headers = response.headers
+
+        aggregate_failures do
+          expect(response).to have_http_status(:unauthorized)
+          expect(headers["access-token"]).to be_blank
+          expect(headers["client"]).to be_blank
+          expect(headers["expiry"]).to be_blank
+          expect(headers["uid"]).to be_blank
+          expect(headers["token-type"]).to be_blank
+        end
+      end
+    end
+
+    context "パスワードに誤りがあったとき" do
+      let!(:user) { create(:user) }
+      let(:params) { { email: user.email, password: "dummy_password" } }
+
+      it "トークン情報を取得できない" do
+        subject
+
+        headers = response.headers
+
+        aggregate_failures do
+          expect(response).to have_http_status(:unauthorized)
+          expect(headers["access-token"]).to be_blank
+          expect(headers["client"]).to be_blank
+          expect(headers["expiry"]).to be_blank
+          expect(headers["uid"]).to be_blank
+          expect(headers["token-type"]).to be_blank
+        end
+      end
+    end
+  end
+
+  describe "DELETE /api/v1/auth/sign_out" do
+    subject { delete(destroy_api_v1_user_session, params: params) }
+
+    context "ログイン済みのユーザーの情報を送ったとき" do
+    end
+
+    context "未ログインユーザーの情報を送ったとき" do
+    end
   end
 end

--- a/spec/requests/api/v1/auth/sessions_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_spec.rb
@@ -66,12 +66,25 @@ RSpec.describe "Api::V1::Auth::Sessions", type: :request do
   end
 
   describe "DELETE /api/v1/auth/sign_out" do
-    subject { delete(destroy_api_v1_user_session, params: params) }
+    # サインアウト時は、ログインしていることが前提なので、ヘッダー情報を送る。
+    subject { delete(destroy_api_v1_user_session_path, params: params, headers: headers) }
 
     context "ログイン済みのユーザーの情報を送ったとき" do
-    end
 
-    context "未ログインユーザーの情報を送ったとき" do
+      let(:user) { create(:user) }
+      let(:params) { { email: user.email, password: user.password } }
+      let!(:headers) { authentication_headers_for(user) }
+
+      it "トークン情報が削除される" do
+        aggregate_failures do
+          expect { subject }.to change { user.reload.tokens }.from(be_present).to(be_empty)
+
+          res = JSON.parse(response.body)
+
+          expect(response).to have_http_status(:ok)
+          expect(res["success"]).to be true
+        end
+      end
     end
   end
 end

--- a/spec/support/session_helpers.rb
+++ b/spec/support/session_helpers.rb
@@ -1,0 +1,5 @@
+module SessionHelpers
+  def authentication_headers_for(user)
+    user.create_new_auth_token
+  end
+end


### PR DESCRIPTION
## 概要
- articles_spec の stub user を使ったテストを、devise user を使ったテストに差し替え
- devise_token_auth gem の機能を使った、「新規登録」「サインイン」「サインアウト」の API テストを追加
